### PR TITLE
scaden training demo: Reduce RAM usage

### DIFF
--- a/scaden/scaden_main.py
+++ b/scaden/scaden_main.py
@@ -62,6 +62,7 @@ def training(data_path, train_datasets, model_dir, batch_size, learning_rate, nu
         cdn256.hidden_units = M256_HIDDEN_UNITS
         cdn256.do_rates = M256_DO_RATES
         cdn256.train(input_path=data_path, train_datasets=train_datasets)
+    del cdn256
 
     # Training of mid model
     print("Training M512 Model ...")
@@ -76,6 +77,7 @@ def training(data_path, train_datasets, model_dir, batch_size, learning_rate, nu
         cdn512.hidden_units = M512_HIDDEN_UNITS
         cdn512.do_rates = M512_DO_RATES
         cdn512.train(input_path=data_path, train_datasets=train_datasets)
+    del cdn512
 
     # Training of large model
     print("Training M1024 Model ...")
@@ -90,6 +92,7 @@ def training(data_path, train_datasets, model_dir, batch_size, learning_rate, nu
         cdn1024.hidden_units = M1024_HIDDEN_UNITS
         cdn1024.do_rates = M1024_DO_RATES
         cdn1024.train(input_path=data_path, train_datasets=train_datasets)
+    del cdn1024
 
     print("Training finished.")
 


### PR DESCRIPTION
Before 7186MB RAM. After 2758MB RAM. While I was getting familiar with the code I ran some memory profiling and I found a simple change that reduces the peak RAM usage in the demo training from 7186MB to 2758MB. We use 60% less RAM than before :slightly_smiling_face:

## Memory profile of the training part of the demo:

#### Before

```
Line #    Mem usage    Increment   Line Contents
================================================
    35    279.8 MiB    279.8 MiB   @profile
    36                             def training(data_path, train_datasets, model_dir, batch_size, learning_rate, num_steps):
    37                                 """
    38                                 Perform training of three a scaden model ensemble consisting of three different models
    39                                 :param model_dir:
    40                                 :param batch_size:
    41                                 :param learning_rate:
    42                                 :param num_steps:
    43                                 :return:
    44                                 """
    45                                 # Convert training datasets
    46    279.8 MiB      0.0 MiB       if train_datasets == '':
    47                                     train_datasets = []
    48                                 else:
    49    279.8 MiB      0.0 MiB           train_datasets = train_datasets.split()
    50    279.8 MiB      0.0 MiB       print("Training on: " + str(train_datasets))
    51                             
    52                             
    53                                 # M256 model training
    54    279.8 MiB      0.0 MiB       print("Training M256 Model ...")
    55    279.8 MiB      0.0 MiB       tf.reset_default_graph()
    56    282.6 MiB      2.8 MiB       with tf.Session() as sess:
    57    282.6 MiB      0.0 MiB           cdn256 = Scaden(sess=sess,
    58    282.6 MiB      0.0 MiB                        model_dir=model_dir+"/m256",
    59    282.6 MiB      0.0 MiB                        model_name='m256',
    60    282.6 MiB      0.0 MiB                        batch_size=batch_size,
    61    282.6 MiB      0.0 MiB                        learning_rate=learning_rate,
    62    282.6 MiB      0.0 MiB                        num_steps=num_steps)
    63    282.6 MiB      0.0 MiB           cdn256.hidden_units = M256_HIDDEN_UNITS
    64    282.6 MiB      0.0 MiB           cdn256.do_rates = M256_DO_RATES
    65   2573.6 MiB   2290.9 MiB           cdn256.train(input_path=data_path, train_datasets=train_datasets)
    66                             
    67                                 # Training of mid model
    68   2573.6 MiB      0.0 MiB       print("Training M512 Model ...")
    69   2573.6 MiB      0.0 MiB       tf.reset_default_graph()
    70   2573.6 MiB      0.0 MiB       with tf.Session() as sess:
    71   2573.6 MiB      0.0 MiB           cdn512 = Scaden(sess=sess,
    72   2573.6 MiB      0.0 MiB                        model_dir=model_dir+"/m512",
    73   2573.6 MiB      0.0 MiB                        model_name='m512',
    74   2573.6 MiB      0.0 MiB                        batch_size=batch_size,
    75   2573.6 MiB      0.0 MiB                        learning_rate=learning_rate,
    76   2573.6 MiB      0.0 MiB                        num_steps=num_steps)
    77   2573.6 MiB      0.0 MiB           cdn512.hidden_units = M512_HIDDEN_UNITS
    78   2573.6 MiB      0.0 MiB           cdn512.do_rates = M512_DO_RATES
    79   4825.5 MiB   2252.0 MiB           cdn512.train(input_path=data_path, train_datasets=train_datasets)
    80                             
    81                                 # Training of large model
    82   4825.5 MiB      0.0 MiB       print("Training M1024 Model ...")
    83   4825.5 MiB      0.0 MiB       tf.reset_default_graph()
    84   4825.5 MiB      0.0 MiB       with tf.Session() as sess:
    85   4825.5 MiB      0.0 MiB           cdn1024 = Scaden(sess=sess,
    86   4825.5 MiB      0.0 MiB                         model_dir=model_dir+"/m1024",
    87   4825.5 MiB      0.0 MiB                         model_name='m1024',
    88   4825.5 MiB      0.0 MiB                         batch_size=batch_size,
    89   4825.5 MiB      0.0 MiB                         learning_rate=learning_rate,
    90   4825.5 MiB      0.0 MiB                         num_steps=num_steps)
    91   4825.5 MiB      0.0 MiB           cdn1024.hidden_units = M1024_HIDDEN_UNITS
    92   4825.5 MiB      0.0 MiB           cdn1024.do_rates = M1024_DO_RATES
    93   7186.7 MiB   2361.1 MiB           cdn1024.train(input_path=data_path, train_datasets=train_datasets)
    94                             
    95   7186.7 MiB      0.0 MiB       print("Training finished.")
```

#### After

```
Line #    Mem usage    Increment   Line Contents
================================================
    35    280.1 MiB    280.1 MiB   @profile
    36                             def training(data_path, train_datasets, model_dir, batch_size, learning_rate, num_steps):
    37                                 """
    38                                 Perform training of three a scaden model ensemble consisting of three different models
    39                                 :param model_dir:
    40                                 :param batch_size:
    41                                 :param learning_rate:
    42                                 :param num_steps:
    43                                 :return:
    44                                 """
    45                                 # Convert training datasets
    46    280.1 MiB      0.0 MiB       if train_datasets == '':
    47                                     train_datasets = []
    48                                 else:
    49    280.1 MiB      0.0 MiB           train_datasets = train_datasets.split()
    50    280.1 MiB      0.0 MiB       print("Training on: " + str(train_datasets))
    51                             
    52                             
    53                                 # M256 model training
    54    280.1 MiB      0.0 MiB       print("Training M256 Model ...")
    55    280.1 MiB      0.0 MiB       tf.reset_default_graph()
    56    282.9 MiB      2.8 MiB       with tf.Session() as sess:
    57    282.9 MiB      0.0 MiB           cdn256 = Scaden(sess=sess,
    58    282.9 MiB      0.0 MiB                        model_dir=model_dir+"/m256",
    59    282.9 MiB      0.0 MiB                        model_name='m256',
    60    282.9 MiB      0.0 MiB                        batch_size=batch_size,
    61    282.9 MiB      0.0 MiB                        learning_rate=learning_rate,
    62    282.9 MiB      0.0 MiB                        num_steps=num_steps)
    63    282.9 MiB      0.0 MiB           cdn256.hidden_units = M256_HIDDEN_UNITS
    64    282.9 MiB      0.0 MiB           cdn256.do_rates = M256_DO_RATES
    65   2574.8 MiB   2291.9 MiB           cdn256.train(input_path=data_path, train_datasets=train_datasets)
    66   1537.5 MiB      0.0 MiB       del cdn256
    67                             
    68                                 # Training of mid model
    69   1537.5 MiB      0.0 MiB       print("Training M512 Model ...")
    70   1537.5 MiB      0.0 MiB       tf.reset_default_graph()
    71    401.8 MiB      0.0 MiB       with tf.Session() as sess:
    72    401.8 MiB      0.0 MiB           cdn512 = Scaden(sess=sess,
    73    401.8 MiB      0.0 MiB                        model_dir=model_dir+"/m512",
    74    401.8 MiB      0.0 MiB                        model_name='m512',
    75    401.8 MiB      0.0 MiB                        batch_size=batch_size,
    76    401.8 MiB      0.0 MiB                        learning_rate=learning_rate,
    77    401.8 MiB      0.0 MiB                        num_steps=num_steps)
    78    401.8 MiB      0.0 MiB           cdn512.hidden_units = M512_HIDDEN_UNITS
    79    401.8 MiB      0.0 MiB           cdn512.do_rates = M512_DO_RATES
    80   2643.1 MiB   2241.4 MiB           cdn512.train(input_path=data_path, train_datasets=train_datasets)
    81   1605.9 MiB      0.0 MiB       del cdn512
    82                             
    83                                 # Training of large model
    84   1605.9 MiB      0.0 MiB       print("Training M1024 Model ...")
    85   1605.9 MiB      0.0 MiB       tf.reset_default_graph()
    86    424.7 MiB      0.0 MiB       with tf.Session() as sess:
    87    424.7 MiB      0.0 MiB           cdn1024 = Scaden(sess=sess,
    88    424.7 MiB      0.0 MiB                         model_dir=model_dir+"/m1024",
    89    424.7 MiB      0.0 MiB                         model_name='m1024',
    90    424.7 MiB      0.0 MiB                         batch_size=batch_size,
    91    424.7 MiB      0.0 MiB                         learning_rate=learning_rate,
    92    424.7 MiB      0.0 MiB                         num_steps=num_steps)
    93    424.7 MiB      0.0 MiB           cdn1024.hidden_units = M1024_HIDDEN_UNITS
    94    424.7 MiB      0.0 MiB           cdn1024.do_rates = M1024_DO_RATES
    95   2757.9 MiB   2333.1 MiB           cdn1024.train(input_path=data_path, train_datasets=train_datasets)
    96   1720.4 MiB      0.0 MiB       del cdn1024
    97                             
    98   1720.4 MiB      0.0 MiB       print("Training finished.")
```

For your curiosity, here is the processing part:

```
Line #    Mem usage    Increment   Line Contents
================================================
   148    280.6 MiB    280.6 MiB   @profile
   149                             def processing(data_path, training_data, processed_path):
   150                                 """
   151                                 Process a training dataset to contain only the genes also available in the prediction data
   152                                 :param data_path: path to prediction data
   153                                 :param training_data: path to training data (h5ad file)
   154                                 :param processed_path: name of processed file
   155                                 :return:
   156                                 """
   157                                 # Get the common genes (signature genes)
   158   1725.5 MiB   1444.9 MiB       raw_input = sc.read_h5ad(training_data)
   159   1725.5 MiB      0.0 MiB       sig_genes_complete = list(raw_input.var_names)
   160   1731.1 MiB      5.5 MiB       sig_genes = get_signature_genes(input_path=data_path, sig_genes_complete=sig_genes_complete)
   161                             
   162                                 # Pre-process data with new signature genes
   163   1731.1 MiB      0.0 MiB       preprocess_h5ad_data(raw_input_path=training_data,
   164   1731.1 MiB      0.0 MiB                            processed_path=processed_path,
   165   3123.6 MiB   1392.5 MiB                            sig_genes=sig_genes)

```

And the prediction part:

```
Line #    Mem usage    Increment   Line Contents
================================================
    97    279.3 MiB    279.3 MiB   @profile
    98                             def prediction(model_dir, data_path, out_name):
    99                                 """
   100                                 Perform prediction using a trained scaden ensemble
   101                                 :param model_dir: the directory containing the models
   102                                 :param data_path: the path to the gene expression file
   103                                 :param out_name: name of the output prediction file
   104                                 :return:
   105                                 """
   106                             
   107                                 # Small model predictions
   108    279.3 MiB      0.0 MiB       tf.reset_default_graph()
   109    282.1 MiB      2.7 MiB       with tf.Session() as sess:
   110    282.1 MiB      0.0 MiB           cdn256 = Scaden(sess=sess,
   111    282.1 MiB      0.0 MiB                        model_dir=model_dir + "/m256",
   112    282.1 MiB      0.0 MiB                        model_name='m256')
   113    282.1 MiB      0.0 MiB           cdn256.hidden_units = M256_HIDDEN_UNITS
   114    282.1 MiB      0.0 MiB           cdn256.do_rates = M256_DO_RATES
   115                             
   116                                     # Predict ratios
   117    441.4 MiB    159.4 MiB           preds_256 = cdn256.predict(input_path=data_path,  out_name='scaden_predictions_m256.txt')
   118                             
   119                             
   120                                 # Mid model predictions
   121    441.4 MiB      0.0 MiB       tf.reset_default_graph()
   122    441.4 MiB      0.0 MiB       with tf.Session() as sess:
   123    441.4 MiB      0.0 MiB           cdn512 = Scaden(sess=sess,
   124    441.4 MiB      0.0 MiB                        model_dir=model_dir+"/m512",
   125    441.4 MiB      0.0 MiB                        model_name='m512')
   126    441.4 MiB      0.0 MiB           cdn512.hidden_units = M512_HIDDEN_UNITS
   127    441.4 MiB      0.0 MiB           cdn512.do_rates = M512_DO_RATES
   128                             
   129                                     # Predict ratios
   130    560.6 MiB    119.2 MiB           preds_512 = cdn512.predict(input_path=data_path, out_name='scaden_predictions_m512.txt')
   131                             
   132                                 # Large model predictions
   133    560.6 MiB      0.0 MiB       tf.reset_default_graph()
   134    560.6 MiB      0.0 MiB       with tf.Session() as sess:
   135    560.6 MiB      0.0 MiB           cdn1024 = Scaden(sess=sess,
   136    560.6 MiB      0.0 MiB                         model_dir=model_dir+"/m1024",
   137    560.6 MiB      0.0 MiB                         model_name='m1024')
   138    560.6 MiB      0.0 MiB           cdn1024.hidden_units = M1024_HIDDEN_UNITS
   139    560.6 MiB      0.0 MiB           cdn1024.do_rates = M1024_DO_RATES
   140                             
   141                                     # Predict ratios
   142    703.9 MiB    143.3 MiB           preds_1024 = cdn1024.predict(input_path=data_path, out_name='scaden_predictions_m1024.txt')
   143                             
   144                                 # Average predictions
   145    703.9 MiB      0.0 MiB       preds = (preds_256 + preds_512 + preds_1024) / 3
   146    703.9 MiB      0.0 MiB       preds.to_csv(out_name, sep="\t")
```

Further performance improvements will be discussed in other issues / PR if that is fine for you :-)
