### PR TITLE
Use anndata instead of scanpy

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -22,12 +22,10 @@ requirements:
   run:
     - python {{ python }}
     - pandas
-    - numpy >=1.14
+    - numpy
     - scikit-learn
-    - scipy
-    - seaborn
+    - anndata
     - tensorflow >=2.0
-    - matplotlib
     - scanpy
     - tqdm
     - click

--- a/scaden/model/functions.py
+++ b/scaden/model/functions.py
@@ -2,7 +2,7 @@
 Functions used for the scaden model
 """
 import collections
-import scanpy.api as sc
+from anndata import read_h5ad
 import numpy as np
 import tensorflow as tf
 from sklearn import preprocessing as pp
@@ -53,7 +53,7 @@ def preprocess_h5ad_data(raw_input_path, processed_path, scaling_option="log_min
     :return:
     """
     print("Pre-processing raw data ...")
-    raw_input = sc.read_h5ad(raw_input_path)
+    raw_input = read_h5ad(raw_input_path)
 
     print("Subsetting genes ...")
     # Select features go use

--- a/scaden/model/scaden.py
+++ b/scaden/model/scaden.py
@@ -5,7 +5,7 @@ import os
 import tensorflow as tf
 import numpy as np
 import pandas as pd
-import scanpy.api as sc
+from anndata import read_h5ad
 import collections
 from .functions import dummy_labels, sample_scaling
 from tqdm import tqdm
@@ -148,7 +148,7 @@ class Scaden(object):
         :param datasets: a list of datasets to extract from the file
         :return: Dataset object
         """
-        raw_input = sc.read_h5ad(input_path)
+        raw_input = read_h5ad(input_path)
 
         # Subset dataset
         if len(datasets) > 0:

--- a/scaden/scaden_main.py
+++ b/scaden/scaden_main.py
@@ -10,10 +10,10 @@ Contains code to
 
 # Imports
 import tensorflow as tf
-import scanpy.api as sc
+from anndata import read_h5ad
 from scaden.model.architectures import architectures
 from scaden.model.scaden import Scaden
-from scaden.model.functions import *
+from scaden.model.functions import get_signature_genes, preprocess_h5ad_data
 
 """
 PARAMETERS
@@ -157,7 +157,7 @@ def processing(data_path, training_data, processed_path, var_cutoff):
     :return:
     """
     # Get the common genes (signature genes)
-    raw_input = sc.read_h5ad(training_data)
+    raw_input = read_h5ad(training_data)
     sig_genes_complete = list(raw_input.var_names)
     sig_genes = get_signature_genes(input_path=data_path, sig_genes_complete=sig_genes_complete, var_cutoff=var_cutoff)
 

--- a/setup.py
+++ b/setup.py
@@ -25,15 +25,16 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires = [
-        'pandas==0.21',
-        'numpy==1.14.5',
+        'pandas',
+        'numpy',
         'scikit-learn',
         'scipy',
-        'seaborn',
         'tensorflow>=2.0',
-        'matplotlib',
-        'scanpy==1.2.2',
+        'anndata',
         'tqdm',
         'click'
-    ]
+    ],
+    extras_require = {
+        'scanpy':  ["scanpy", "matplotlib", "seaborn"]
+    }
 )


### PR DESCRIPTION
scanpy uses anndata to read h5ad files. We can use
anndata directly and avoid the bigger scanpy direct dependency.

With this commit, scanpy, matplotlib and seaborn become extra
dependencies, so they are not mandatory to be installed.