### PR TITLE
Add installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,17 +24,88 @@ hardware (e.g. GPU), however we recommend to have at least 16 GB of memory.
 Scaden requires Python 3. All package dependencies should be handled automatically when installing with pip or conda.
 
 ### 2. Installation guide
-The recommended way to install Scaden is using conda and the Bioconda channel:
 
-`conda install -c bioconda scaden`
+#### Stable version
 
-Instllation with conda takes only a few minutes (2-5), depending on the internet connetion.
-Alternatively Scaden can be installed with pip:
+The recommended way to install Scaden is using conda and the Bioconda channel.
 
-`pip install scaden`
+You can create a conda environment for your scaden installation to minimize package conflicts:
+
+```bash
+conda create -n scaden_env --override-channels -c defaults -c conda-forge -c bioconda scaden
+```
+
+`scaden` depends on `tensorflow`. On conda `tensorflow` uses the CPU to train the networks.
+ If you have a `cuda` capable GPU, you may want to install the `tensorflow-gpu` conda package as well
+so scaden uses the gpu instead:
+
+```bash
+conda activate scaden_env
+conda install tensorflow-gpu
+```
+
+Installation with `conda` takes only a few minutes (2-5), depending on the internet connection.
+
+Alternatively Scaden can be installed with `pip`:
+
+```bash
+# Create a virtual environment:
+python3 -m venv ./venv
+# Activate the virtual environment with:
+source ./venv/bin/activate
+# Upgrade pip and wheel:
+python3 -m pip install -U pip wheel
+# Install scaden:
+python3 -m pip install -U scaden
+```
 
 We also provide a docker image with Scaden installed:
 [https://hub.docker.com/r/kevinmenden/scaden](https://hub.docker.com/r/kevinmenden/scaden)
+
+#### Development version
+
+To build and install the dev version
+
+```bash
+# Clone the repository
+git clone https://github.com/KevinMenden/scaden.git
+git checkout dev
+# Enter scaden
+cd scaden
+# Install conda-build and conda-verify:
+conda install conda-build conda-verify
+# Build the conda package:
+conda build --override-channels -c defaults -c conda-forge -c bioconda conda.recipe/
+# Install the built package in a new environment (using the local channel)
+conda create -n scaden_env_dev --override-channels -c local -c defaults -c conda-forge -c bioconda scaden
+# Optionally, install tensorflow-gpu:
+conda activate scaden_env_dev && conda install tensorflow-gpu
+```
+
+To develop scaden, it may be practical to use `conda develop`:
+
+```bash
+# Clone the repository
+git clone https://github.com/KevinMenden/scaden.git
+git checkout dev
+# Enter scaden
+cd scaden
+# Install conda-build and conda-verify:
+conda install conda-build conda-verify
+# Build the conda package:
+conda build --override-channels -c defaults -c conda-forge -c bioconda conda.recipe/
+# Install scaden dependencies (only the dependencies, not scaden)
+conda create -n scaden_env_dev --only-deps --override-channels -c local -c defaults -c conda-forge -c bioconda scaden
+# Activate the development environment you just created
+conda activate scaden_env_dev
+# Optionally, install tensorflow-gpu:
+conda install tensorflow-gpu
+# Create a new branch for the feature you are working at:
+git checkout -b feature-a-cool-enhancement
+# Install scaden in development mode
+conda develop .
+```
+
 
 ### 3. Demo
 We provide several curated [training datasets](https://scaden.readthedocs.io/en/latest/datasets/) for Scaden. For this demo,


### PR DESCRIPTION
Hey Kevin,

I wrote detailed installation instructions, separating the "stable version" (published in conda/pypi) from the "development version" from github.

The instructions include how to enable the GPU on tensorflow.

If you think that the "development version" instructions should be out of the `README` (e.g. in a `CONTRIBUTING.md` file), please tell me and I will move them there.