### PR TITLE
Add script for Dockerfile auto-builds

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,0 +1,49 @@
+# BASE_IMAGE is either "nvidia/cuda:10.1-runtime-ubuntu18.04" or "library/ubuntu:18.04"
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+#
+# Install Miniconda in /opt/conda
+#
+
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+ENV PATH /opt/conda/bin:$PATH
+
+RUN apt-get update --fix-missing && \
+    apt-get install -y wget bzip2 ca-certificates curl git && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-4.7.12.1-Linux-x86_64.sh -O ~/miniconda.sh && \
+    /bin/bash ~/miniconda.sh -b -p /opt/conda && \
+    rm ~/miniconda.sh && \
+    /opt/conda/bin/conda clean -tipsy && \
+    ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
+    echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
+    echo "conda activate base" >> ~/.bashrc
+
+ENV LD_LIBRARY_PATH /usr/local/cuda-10.1/lib64:/usr/local/cuda-10.1/extras/CUPTI/lib64:$LD_LIBRARY_PATH
+
+COPY . /src
+WORKDIR /src
+
+ARG CPU_OR_GPU
+
+RUN conda update -n base -c defaults conda \
+  && conda install conda-build conda-verify \
+  && conda build --override-channels -c defaults -c conda-forge -c bioconda conda.recipe/ \
+  && cd / \
+  && rm -rf /src \
+  && conda install --override-channels -c local -c defaults -c conda-forge -c bioconda scaden \
+  && conda remove conda-build conda-verify \
+  && conda clean -a
+
+# Needed for when the docker container uses a non-root user id
+RUN mkdir /tmp/numba_cache & chmod 777 /tmp/numba_cache & NUMBA_CACHE_DIR=/tmp/numba_cache
+
+RUN if [ "x$CPU_OR_GPU" = "xgpu" ]; then \
+      conda install tensorflow-gpu && \
+      conda clean -a; \
+    fi
+
+WORKDIR /

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+
+# DOCKER_TAG and IMAGE_NAME are set by the docker hub autobuild system
+#  https://docs.docker.com/docker-hub/builds/advanced/
+
+# Determine if building GPU or CPU image:
+## First from DOCKER_TAG:
+if [[ "${DOCKER_TAG}" == *gpu ]]; then
+  CPU_OR_GPU="gpu"
+fi
+
+if [[ "${DOCKER_TAG}" == *cpu ]]; then
+  CPU_OR_GPU="cpu"
+fi
+
+## If it is a local build, build cpu
+if [ "x${CPU_OR_GPU}" = "x" ]; then
+  CPU_OR_GPU="cpu"
+fi
+
+# If it is a local build, give an image name:
+if [ "x${IMAGE_NAME}" = "x" ]; then
+  IMAGE_NAME="scaden-${CPU_OR_GPU}:dev"
+fi
+
+# Choose base image for cpu or gpu:
+if [ "${CPU_OR_GPU}" = "gpu" ]; then
+  BASE_IMAGE="nvidia/cuda:10.1-runtime-ubuntu18.04"
+else
+  BASE_IMAGE="ubuntu:18.04"
+fi
+
+# Build:
+echo "Building ${IMAGE_NAME}"
+docker build \
+  -t "${IMAGE_NAME}" \
+  --build-arg BASE_IMAGE="${BASE_IMAGE}" \
+  --build-arg CPU_OR_GPU="${CPU_OR_GPU}" \
+  -f Dockerfile-dev \
+  .


### PR DESCRIPTION
This pull request, in combination with the docker hub autobuild system allows us to create two docker images for each `git tag` that is pushed (e.g. `KevinMenden/scaden:v0.9.4-cpu` and `KevinMenden/scaden:v0.9.4-gpu`) as well as two docker images that will track the dev branch.
You will need to setup the autobuilds in the docker hub repository following the image below:

![Screenshot_20200227-214339](https://user-images.githubusercontent.com/75441/75485906-dec5b500-59ab-11ea-9051-2997ba069a95.png)


I already tried this on  https://hub.docker.com/r/zeehio/scaden/tags for testing and it works great.
