### PR TITLE
Replace deprecated as_matrix() with to_numpy()

### DIFF
--- a/scaden/preprocessing/create_h5ad_file.py
+++ b/scaden/preprocessing/create_h5ad_file.py
@@ -106,7 +106,7 @@ for i, train_file in enumerate(datasets):
 
 
     print("Processing " + str(train_file))
-    adata.append(anndata.AnnData(X=x.as_matrix(),
+    adata.append(anndata.AnnData(X=x.to_numpy(),
                                  obs=ratios,
                                  var=pd.DataFrame(columns=[], index=list(x))))
 import gc


### PR DESCRIPTION
The deprecated https://pandas.pydata.org/pandas-docs/version/0.25.1/reference/api/pandas.DataFrame.as_matrix.html suggests to use https://pandas.pydata.org/pandas-docs/version/0.25.1/reference/api/pandas.DataFrame.values.html#pandas.DataFrame.values which in turn points to https://pandas.pydata.org/pandas-docs/version/0.25.1/reference/api/pandas.DataFrame.to_numpy.html#pandas.DataFrame.to_numpy

Closes #40 