### PR TITLE
ADD h5ad input format option

### DIFF
--- a/scaden/__main__.py
+++ b/scaden/__main__.py
@@ -193,7 +193,12 @@ Simulate dataset
     default="data",
     help="Prefix to append to training .h5ad file [default: data]",
 )
-def simulate(out, data, cells, n_samples, pattern, unknown, prefix):
+@click.option(
+    "--fmt",
+    default="txt",
+    help="Input format sc data txt or h5ad [default: txt]",
+)
+def simulate(out, data, cells, n_samples, pattern, unknown, prefix, fmt):
     """ Create artificial bulk RNA-seq data from scRNA-seq dataset(s)"""
     simulation(
         simulate_dir=out,
@@ -203,6 +208,7 @@ def simulate(out, data, cells, n_samples, pattern, unknown, prefix):
         pattern=pattern,
         unknown_celltypes=unknown,
         out_prefix=prefix,
+        fmt=fmt
     )
 
 

--- a/scaden/simulate.py
+++ b/scaden/simulate.py
@@ -8,12 +8,12 @@ and subsequenbt formatting in .h5ad file for training with Scaden
 
 
 def simulation(simulate_dir, data_dir, sample_size, num_samples, pattern,
-               unknown_celltypes, out_prefix):
+               unknown_celltypes, out_prefix, fmt):
 
     # Perform the bulk simulation
     unknown_celltypes = list(unknown_celltypes)
     simulate_bulk(sample_size, num_samples, data_dir, simulate_dir, pattern,
-                  unknown_celltypes)
+                  unknown_celltypes, fmt)
 
     # Create the h5ad training data file
     out_name = os.path.join(simulate_dir, out_prefix + ".h5ad")


### PR DESCRIPTION
For large and/or multiple sc datasets (_e.g._ datasets that are split into multiple samples), `pd.read_table()` is inefficient, and
just reading in data can take hours. This also requires creating and temporarily storing potentially many large 
txt files (`_count.txt` and `_celltypes.txt`). Adding the option to input files in `h5ad` format is  much more efficient, _e.g._
on my data I reduce running time from hours and even days to a few minutes. This is also much more compact, as both counts and cell types can be stored in the same file for each input dataset. 

Additionally, it might be worth also writing the several output files 

```
tmpx.to_csv(out_dir + datasets[i] + "_samples.txt", sep="\t", index=False)
tmpy.to_csv(out_dir + datasets[i] + "_labels.txt", sep="\t", index=False)
```

in `bulk_simulation.py` directly in `h5ad` format, which would require _e.g._  also adjusting `create_h5ad_file.py`.
